### PR TITLE
Modular

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,19 +40,19 @@ Usage examples
 .. code:: bash
 
     # Assume requirements in requirements.txt; doesn't tag build image
-    pydockerize
+    pydockerize write_dockerfiles build
 
     # Add a tag to built image
-    pydockerize -t my_cool_app
+    pydockerize -t my_cool_app write_dockerfiles build
 
     # Specifies a requirements file
-    pydockerize -t my_cool_app requirements-prod.txt
+    pydockerize -t my_cool_app requirements-prod.txt write_dockerfiles build
 
     # Specify multiple Python versions to build Docker images for
-    pydockerize.py -t my_cool_app --python-versions 2.7,3.4
+    pydockerize.py -t my_cool_app --python-versions 2.7,3.4 write_dockerfiles build
 
     # Specify a command to invoke when running container
-    pydockerize.py -t my_cool_app --cmd "pserve app.ini"
+    pydockerize.py -t my_cool_app --cmd "pserve app.ini" write_dockerfiles build
 
 Setting the ``CMD`` for image
 =============================

--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ Usage
 ::
 
     $ pydockerize --help
-    Usage: pydockerize [OPTIONS] [REQUIREMENTS_FILE]
+    Usage: pydockerize [OPTIONS] COMMAND1 [ARGS]... [COMMAND2 [ARGS]...]...
 
       Create Docker images for Python apps
 
@@ -32,7 +32,13 @@ Usage
       -t, --tag TEXT              Repository name (and optionally a tag) to be
                                   applied to the resulting image in case of
                                   success
+      -r, --requirement PATH
       --help                      Show this message and exit.
+
+    Commands:
+      build              Run `docker build` with Dockerfile(s) from
+                         `write_dockerfiles`
+      write_dockerfiles  Write Dockerfile(s)
 
 Usage examples
 ==============

--- a/pydockerize.py
+++ b/pydockerize.py
@@ -71,7 +71,7 @@ def pydockerize(ctx, requirements_file, tag, cmd, entrypoint, procfile,
 
 @pydockerize.command()
 @click.pass_context
-def write_dockerfiles(ctx):
+def generate(ctx):
     """Write Dockerfile(s)"""
 
     base_images = ctx.obj['base_images']
@@ -79,17 +79,16 @@ def write_dockerfiles(ctx):
     cmd = ctx.obj['cmd']
     entrypoint = ctx.obj['entrypoint']
 
-    click.echo('write_dockerfiles: base_images = %r' % base_images)
-    click.echo('write_dockerfiles: requirements_file = %r' % requirements_file)
-    click.echo('write_dockerfiles: cmd = %r' % cmd)
-    click.echo('write_dockerfiles: entrypoint = %r' % entrypoint)
+    click.echo('generate: base_images = %r' % base_images)
+    click.echo('generate: requirements_file = %r' % requirements_file)
+    click.echo('generate: cmd = %r' % cmd)
+    click.echo('generate: entrypoint = %r' % entrypoint)
 
     base_images_and_filenames = []
 
     for base_image in base_images:
         filename = get_filename_from_base_image(base_image, base_images)
-        write_dockerfile(base_image, requirements_file,
-                         filename, cmd, entrypoint)
+        generate_one(base_image, requirements_file, filename, cmd, entrypoint)
         base_images_and_filenames.append((base_image, filename))
 
     ctx.obj['base_images_and_filenames'] = base_images_and_filenames
@@ -108,9 +107,9 @@ def get_cmd_from_procfile(procfile):
     return lines[0].split(':')[1].strip()
 
 
-def write_dockerfile(base_image, requirements_file, filename, cmd, entrypoint):
-    click.echo('write_dockerfile: base_image = %r' % base_image)
-    click.echo('write_dockerfile: Writing %s' % filename)
+def generate_one(base_image, requirements_file, filename, cmd, entrypoint):
+    click.echo('generate_one: base_image = %r' % base_image)
+    click.echo('generate_one: Writing %s' % filename)
 
     with open(filename, 'w+') as f:
         f.write(textwrap.dedent("""\
@@ -140,11 +139,11 @@ def write_dockerfile(base_image, requirements_file, filename, cmd, entrypoint):
     return filename
 
 
-@pydockerize.command(short_help="Run `docker build` with Dockerfile(s) from "
-                                "`write_dockerfiles`")
+@pydockerize.command(
+    short_help="Run `docker build` with Dockerfile(s) from `generate`")
 @click.pass_context
 def build(ctx):
-    """Run `docker build` with Dockerfile(s) from `write_dockerfiles`"""
+    """Run `docker build` with Dockerfile(s) from `generate`"""
 
     tags_built = []
     tag = ctx.obj['tag']

--- a/pydockerize.py
+++ b/pydockerize.py
@@ -154,7 +154,7 @@ def build(ctx):
 
     for base_image in base_images:
         filename = get_filename_from_base_image(base_image, base_images)
-        tag_built = build_one(tag, base_image, filename)
+        tag_built = build_one(tag, base_image, base_images, filename)
         tags_built.append(tag_built)
 
     click.secho('build: %d Docker build(s) succeeded: %s'
@@ -175,12 +175,12 @@ def images(ctx):
         show_docker_images(tag)
 
 
-def build_one(tag, base_image, filename):
+def build_one(tag, base_image, base_images, filename):
     cmd = ['docker', 'build']
     if tag:
         if ':' in tag:
             raise Exception("':' in tag not supported yet")
-        tag = tag + ':' + get_tag_from_base_image(base_image)
+        tag = tag + ':' + get_tag_from_base_image(base_image, base_images)
         cmd.append('--tag')
         cmd.append(tag)
     if filename != 'Dockerfile':
@@ -213,7 +213,10 @@ def get_filename_from_base_image(base_image, base_images):
         return 'Dockerfile-' + base_image
 
 
-def get_tag_from_base_image(base_image):
+def get_tag_from_base_image(base_image, base_images):
+    if len(base_images) == 1:
+        return 'latest'
+
     tag = base_image
     replacements = {'python:': 'py', '-onbuild': ''}
 

--- a/pydockerize.py
+++ b/pydockerize.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
-
 import os
 import subprocess
 import textwrap
@@ -70,12 +68,12 @@ def pydockerize(ctx, requirements_file, tag, cmd, entrypoint, procfile,
         'tag': tag,
     }
 
-    print('pydockerize: requirements_file = %r' % requirements_file)
-    print('pydockerize: cmd = %r' % cmd)
-    print('pydockerize: entrypoint = %r' % entrypoint)
+    click.echo('pydockerize: requirements_file = %r' % requirements_file)
+    click.echo('pydockerize: cmd = %r' % cmd)
+    click.echo('pydockerize: entrypoint = %r' % entrypoint)
 
     # if tag:
-    #     print('\nShowing Docker images for %s:\n' % tag)
+    #     click.echo('\nShowing Docker images for %s:\n' % tag)
     #     show_docker_images(tag)
 
 
@@ -84,7 +82,7 @@ def pydockerize(ctx, requirements_file, tag, cmd, entrypoint, procfile,
 def write_dockerfiles(ctx):
     """Write Dockerfile(s)"""
 
-    print('********** write_dockerfiles ********')
+    click.echo('********** write_dockerfiles ********')
 
     base_images = ctx.obj['base_images']
     requirements_file = ctx.obj['requirements_file']
@@ -116,8 +114,8 @@ def get_cmd_from_procfile(procfile):
 
 
 def write_dockerfile(base_image, requirements_file, filename, cmd, entrypoint):
-    print('write_dockerfile: base_image = %r' % base_image)
-    print('write_dockerfile: Writing %s' % filename)
+    click.echo('write_dockerfile: base_image = %r' % base_image)
+    click.echo('write_dockerfile: Writing %s' % filename)
 
     with open(filename, 'w+') as f:
         f.write(textwrap.dedent("""\
@@ -156,7 +154,7 @@ def build(ctx):
     tag = ctx.obj['tag']
     base_images = ctx.obj['base_images']
 
-    print('build: tag = %r' % tag)
+    click.echo('build: tag = %r' % tag)
 
     for base_image in base_images:
         filename = get_filename_from_base_image(base_image)
@@ -174,13 +172,15 @@ def build_one(tag, base_image, filename):
     cmd.append('--file')
     cmd.append(filename)
     cmd.append('.')
-    print('build_one: Calling subprocess with cmd = %r\n'
-          % ' '.join(cmd))
+    click.echo('build_one: Calling subprocess with cmd = %r\n'
+               % ' '.join(cmd))
     status = subprocess.call(cmd)
     if status == 0:
-        print('build_one: Docker build succeeded.')
+        click.secho('build_one: Docker build succeeded.',
+                    fg='green')
     else:
-        print('build_one: Docker build failed with %d' % status)
+        click.secho('build_one: Docker build failed with %d' % status,
+                    fg='red')
         raise click.Abort()
 
 

--- a/pydockerize.py
+++ b/pydockerize.py
@@ -61,14 +61,22 @@ def pydockerize(ctx, requirements_file, tag, cmd, entrypoint, procfile,
     if procfile:
         cmd = get_cmd_from_procfile(procfile)
 
-    for base_image in base_images:
-        filename = write_dockerfile(base_image, requirements_file,
-                                    cmd, entrypoint)
+    base_images_and_filenames = write_dockerfiles(
+        base_images, requirements_file, cmd, entrypoint)
+
+    for base_image, filename in base_images_and_filenames:
         invoke_docker_build(tag, base_image, filename)
 
     if tag:
         print('\nShowing Docker images for %s:\n' % tag)
         show_docker_images(tag)
+
+
+def write_dockerfiles(base_images, requirements_file, cmd, entrypoint):
+    for base_image in base_images:
+        filename = write_dockerfile(base_image, requirements_file,
+                                    cmd, entrypoint)
+        yield base_image, filename
 
 
 def get_base_images_from_python_versions(python_versions):

--- a/pydockerize.py
+++ b/pydockerize.py
@@ -82,6 +82,8 @@ def pydockerize(ctx, requirements_file, tag, cmd, entrypoint, procfile,
 @pydockerize.command()
 @click.pass_context
 def write_dockerfiles(ctx):
+    """Write Dockerfile(s)"""
+
     print('********** write_dockerfiles ********')
 
     base_images = ctx.obj['base_images']
@@ -147,9 +149,12 @@ def write_dockerfile(base_image, requirements_file, cmd, entrypoint):
     return filename
 
 
-@pydockerize.command()
+@pydockerize.command(short_help="Run `docker build` with Dockerfile(s) from "
+                                "`write_dockerfiles`")
 @click.pass_context
 def build(ctx):
+    """Run `docker build` with Dockerfile(s) from `write_dockerfiles`"""
+
     tag = ctx.obj['tag']
     base_images_and_filenames = ctx.obj['base_images_and_filenames']
 

--- a/pydockerize.py
+++ b/pydockerize.py
@@ -92,7 +92,7 @@ def write_dockerfiles(ctx):
     base_images_and_filenames = []
 
     for base_image in base_images:
-        filename = get_filename_from_base_image(base_image)
+        filename = get_filename_from_base_image(base_image, base_images)
         write_dockerfile(base_image, requirements_file,
                          filename, cmd, entrypoint)
         base_images_and_filenames.append((base_image, filename))
@@ -157,7 +157,7 @@ def build(ctx):
     click.echo('build: tag = %r' % tag)
 
     for base_image in base_images:
-        filename = get_filename_from_base_image(base_image)
+        filename = get_filename_from_base_image(base_image, base_images)
         build_one(tag, base_image, filename)
 
 
@@ -189,8 +189,11 @@ def show_docker_images(repo):
     return subprocess.call(cmd)
 
 
-def get_filename_from_base_image(base_image):
-    return 'Dockerfile-' + base_image
+def get_filename_from_base_image(base_image, base_images):
+    if len(base_images) == 1:
+        return 'Dockerfile'
+    else:
+        return 'Dockerfile-' + base_image
 
 
 def get_tag_from_base_image(base_image):

--- a/pydockerize.py
+++ b/pydockerize.py
@@ -72,10 +72,6 @@ def pydockerize(ctx, requirements_file, tag, cmd, entrypoint, procfile,
     click.echo('pydockerize: cmd = %r' % cmd)
     click.echo('pydockerize: entrypoint = %r' % entrypoint)
 
-    # if tag:
-    #     click.echo('\nShowing Docker images for %s:\n' % tag)
-    #     show_docker_images(tag)
-
 
 @pydockerize.command()
 @click.pass_context
@@ -159,6 +155,18 @@ def build(ctx):
     for base_image in base_images:
         filename = get_filename_from_base_image(base_image, base_images)
         build_one(tag, base_image, filename)
+
+
+@pydockerize.command()
+@click.pass_context
+def images(ctx):
+    """Show images for repo from --tag"""
+
+    tag = ctx.obj['tag']
+
+    if tag:
+        click.echo('\nShowing Docker images for %s:\n' % tag)
+        show_docker_images(tag)
 
 
 def build_one(tag, base_image, filename):

--- a/pydockerize.py
+++ b/pydockerize.py
@@ -146,6 +146,7 @@ def write_dockerfile(base_image, requirements_file, filename, cmd, entrypoint):
 def build(ctx):
     """Run `docker build` with Dockerfile(s) from `write_dockerfiles`"""
 
+    tags_built = []
     tag = ctx.obj['tag']
     base_images = ctx.obj['base_images']
 
@@ -153,8 +154,12 @@ def build(ctx):
 
     for base_image in base_images:
         filename = get_filename_from_base_image(base_image, base_images)
-        build_one(tag, base_image, filename)
+        tag_built = build_one(tag, base_image, filename)
+        tags_built.append(tag_built)
 
+    click.secho('build: %d Docker build(s) succeeded: %s'
+                % (len(base_images), ', '.join(tags_built)),
+                fg='green')
 
 @pydockerize.command()
 @click.pass_context
@@ -183,10 +188,12 @@ def build_one(tag, base_image, filename):
                % ' '.join(cmd))
     status = subprocess.call(cmd)
     if status == 0:
-        click.secho('build_one: Docker build succeeded.',
+        click.secho('build_one: Docker build for %s succeeded.' % tag,
                     fg='green')
+        return tag
     else:
-        click.secho('build_one: Docker build failed with %d' % status,
+        click.secho('build_one: Docker build for %s failed with %d'
+                    % (tag, status),
                     fg='red')
         raise click.Abort()
 

--- a/pydockerize.py
+++ b/pydockerize.py
@@ -161,6 +161,8 @@ def build(ctx):
                 % (len(base_images), ', '.join(tags_built)),
                 fg='green')
 
+    ctx.invoke(images)
+
 @pydockerize.command()
 @click.pass_context
 def images(ctx):

--- a/pydockerize.py
+++ b/pydockerize.py
@@ -97,7 +97,6 @@ def write_dockerfiles(ctx):
         filename = write_dockerfile(base_image, requirements_file,
                                     cmd, entrypoint)
         base_images_and_filenames.append((base_image, filename))
-        # yield base_image, filename
 
     ctx.obj['base_images_and_filenames'] = base_images_and_filenames
 

--- a/pydockerize.py
+++ b/pydockerize.py
@@ -68,22 +68,21 @@ def pydockerize(ctx, requirements_file, tag, cmd, entrypoint, procfile,
         'tag': tag,
     }
 
-    click.echo('pydockerize: requirements_file = %r' % requirements_file)
-    click.echo('pydockerize: cmd = %r' % cmd)
-    click.echo('pydockerize: entrypoint = %r' % entrypoint)
-
 
 @pydockerize.command()
 @click.pass_context
 def write_dockerfiles(ctx):
     """Write Dockerfile(s)"""
 
-    click.echo('********** write_dockerfiles ********')
-
     base_images = ctx.obj['base_images']
     requirements_file = ctx.obj['requirements_file']
     cmd = ctx.obj['cmd']
     entrypoint = ctx.obj['entrypoint']
+
+    click.echo('write_dockerfiles: base_images = %r' % base_images)
+    click.echo('write_dockerfiles: requirements_file = %r' % requirements_file)
+    click.echo('write_dockerfiles: cmd = %r' % cmd)
+    click.echo('write_dockerfiles: entrypoint = %r' % entrypoint)
 
     base_images_and_filenames = []
 

--- a/pydockerize.py
+++ b/pydockerize.py
@@ -32,8 +32,9 @@ DEFAULT_BASE_IMAGES = ['python:2.7-onbuild']
 @click.option('-t', '--tag',
               help='Repository name (and optionally a tag) to be applied to '
                    'the resulting image in case of success')
-@click.argument('requirements_file', type=click.Path(exists=True),
-                default='requirements.txt')
+@click.option('-r', '--requirement',
+              'requirements_file', type=click.Path(exists=True),
+               default='requirements.txt')
 @click.pass_context
 def pydockerize(ctx, requirements_file, tag, cmd, entrypoint, procfile,
                 base_images=None, python_versions=None):

--- a/pydockerize.py
+++ b/pydockerize.py
@@ -94,8 +94,9 @@ def write_dockerfiles(ctx):
     base_images_and_filenames = []
 
     for base_image in base_images:
-        filename = write_dockerfile(base_image, requirements_file,
-                                    cmd, entrypoint)
+        filename = get_filename_from_base_image(base_image)
+        write_dockerfile(base_image, requirements_file,
+                         filename, cmd, entrypoint)
         base_images_and_filenames.append((base_image, filename))
 
     ctx.obj['base_images_and_filenames'] = base_images_and_filenames
@@ -114,10 +115,8 @@ def get_cmd_from_procfile(procfile):
     return lines[0].split(':')[1].strip()
 
 
-def write_dockerfile(base_image, requirements_file, cmd, entrypoint):
+def write_dockerfile(base_image, requirements_file, filename, cmd, entrypoint):
     print('write_dockerfile: base_image = %r' % base_image)
-
-    filename = 'Dockerfile-' + base_image
     print('write_dockerfile: Writing %s' % filename)
 
     with open(filename, 'w+') as f:
@@ -155,11 +154,12 @@ def build(ctx):
     """Run `docker build` with Dockerfile(s) from `write_dockerfiles`"""
 
     tag = ctx.obj['tag']
-    base_images_and_filenames = ctx.obj['base_images_and_filenames']
+    base_images = ctx.obj['base_images']
 
     print('build: tag = %r' % tag)
 
-    for base_image, filename in base_images_and_filenames:
+    for base_image in base_images:
+        filename = get_filename_from_base_image(base_image)
         build_one(tag, base_image, filename)
 
 
@@ -187,6 +187,10 @@ def build_one(tag, base_image, filename):
 def show_docker_images(repo):
     cmd = ['docker', 'images', repo]
     return subprocess.call(cmd)
+
+
+def get_filename_from_base_image(base_image):
+    return 'Dockerfile-' + base_image
 
 
 def get_tag_from_base_image(base_image):

--- a/pydockerize.py
+++ b/pydockerize.py
@@ -138,9 +138,9 @@ def write_dockerfile(base_image, requirements_file, filename, cmd, entrypoint):
             WORKDIR /host
         """.format(base_image=base_image)))
         if entrypoint:
-            f.write("\nENTRYPOINT " + entrypoint)
+            f.write("\nENTRYPOINT %s\n" % entrypoint)
         if cmd:
-            f.write("\nCMD " + cmd)
+            f.write("\nCMD %s\n" % cmd)
 
     return filename
 

--- a/pydockerize.py
+++ b/pydockerize.py
@@ -183,8 +183,9 @@ def build_one(tag, base_image, filename):
         tag = tag + ':' + get_tag_from_base_image(base_image)
         cmd.append('--tag')
         cmd.append(tag)
-    cmd.append('--file')
-    cmd.append(filename)
+    if filename != 'Dockerfile':
+        cmd.append('--file')
+        cmd.append(filename)
     cmd.append('.')
     click.echo('build_one: Calling subprocess with cmd = %r\n'
                % ' '.join(cmd))


### PR DESCRIPTION
This changes the UI substantially by making it modular.

Instead of `pydockerize` doing everything, there are subcommands: `write_dockerfiles` and `build`. Probably most commonly, they would be chained together:

``` bash
$ pydockerize -t msabramo/pydockerize -p 2.7,3.3,3.4 write_dockerfiles build
```

but the user also has the freedom to do one without the other.

For example, if the user does not have Docker on their system or otherwise prefers not to run `docker build` locally, they can run just the `write_dockerfiles` phase, commit the resulting `Dockerfile`(s) to version control, and then have something else (a CI server?) run the `build` (`docker build`) step.

I might also in the future add more optional steps, like for example:
- a `write_fig`/`write_compose` step that can generate `fig.yml` files for you.
- a `tag_latest` step that can add the `latest` tag to one of the built images.

Cc: @sudarkoff
